### PR TITLE
more details for python

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To build just the standalone variant .bdf files
 (for tewii and tewi2a) run `make var`.
 
 ### Dependencies
-* python (variant generator)
+* python3 (variant generator)
 * bdftopcf (.pcf files)
 
 # CJK Fallbacks


### PR DESCRIPTION
Hi, lucy
1. According to your latest commit 69664bb98950dd6316ceb7e61a126cb0fcd99478 , sys.stdout.detach() is only provided by python3, not python2.
2. I know Arch and Gentoo already switched into python3, but some distros like Crux Linux still use python2 as default, I guess your are a gentoo user, that's why shebang only provides python(since python3 is default for you).
3. Changing shebang in python scripts is a bad idea, at least I think so, so i only changed README. 